### PR TITLE
slideup.pl に transition オプションなどを指定可能にする

### DIFF
--- a/slideup.pl
+++ b/slideup.pl
@@ -4,6 +4,7 @@ use v5.10;
 use strict;
 use warnings;
 
+use Cwd qw(getcwd);
 use File::Basename qw(basename dirname);
 use Getopt::Long qw(:config posix_default no_ignore_case bundling auto_help);
 use Pod::Usage qw(pod2usage);
@@ -45,6 +46,11 @@ push @revealup_arg, "--theme=$theme" if $theme;
 for my $key (@passthrough_args) {
     # これらのオプションは revealup にあるので、存在すればそのまま採用
     push @revealup_arg, "--$key=$opt{$key}" if $opt{$key};
+}
+# オンライン配信にはトランジションは不要
+if ( !grep { /^--transition=/ } @revealup_arg and getcwd() =~ m{\bonline\b} ) {
+    print "slideup.pl: start online mode. transition is off";
+    push @revealup_arg, "--transition=none";
 }
 push @revealup_arg, $markdown_filename;
 

--- a/slideup.pl
+++ b/slideup.pl
@@ -11,12 +11,15 @@ require App::revealup;
 
 use constant DEBUG => $ENV{DEBUG};
 
+my @passthrough_args = (qw(transition widhth height));
+
 GetOptions(
     \my %opt,
     "port|p=i",
     "silent|s",
     "theme|t=s",
     "print-pdf|p",
+    (map { "$_=s" } @passthrough_args),
 );
 
 my $markdown_path = shift;
@@ -39,7 +42,7 @@ chdir dirname($markdown_path);
 
 my @revealup_arg = ("serve", "--port=$port");
 push @revealup_arg, "--theme=$theme" if $theme;
-for my $key (qw(transition widhth height)) {
+for my $key (@passthrough_args) {
     # これらのオプションは revealup にあるので、存在すればそのまま採用
     push @revealup_arg, "--$key=$opt{$key}" if $opt{$key};
 }


### PR DESCRIPTION
revealup にあるページめくりアニメーション指定オプション transition などを指定可能にする修正です。

`./slideup.pl --transtion=none 2nd/slide.md` などとすると、ページめくりアニメーションをオフにできたりします。transition オプションは revealup コマンドに準じます。see: `perldoc App::revealup::cli::serve`

元々 revealup にオプションを伝えるコードは書かれていたのですが、不完全だったために機能していませんでした。

またカレントディレクトリ名を取得して、そこに online という文字が入っていたら、ページめくりアニメーションをオフにする `--transition=none` を自動指定するようにしました。オンライン配信ではページめくりアニメーションにデメリットが目立つため。