### PR TITLE
add <br clear="all">

### DIFF
--- a/1st/msys2_down.md
+++ b/1st/msys2_down.md
@@ -103,6 +103,8 @@ $ bash replace-repo.bash "<IP Address:Port>"
 
 `<IP Address:Port>` の部分は, 別途お伝えします.
 
+<br clear="all">
+
 ___
 ## msys2のセットアップ（６）
 ### リポジトリデータのリストア
@@ -118,6 +120,8 @@ $ bash replace-repo.bash <IP Address:Port>
 <img src="image/replace-repo2.png" align='right' style='width: 30%'>
 
 変更時と同じコマンドを実行します.
+
+<br clear="all">
 
 ___
 

--- a/1st/part1.md
+++ b/1st/part1.md
@@ -48,6 +48,8 @@ Perl 入学式 online 版では、基本的に Web ブラウザ版の環境で�
 
 <img src="image/wandbox01.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## Wandbox
@@ -58,6 +60,8 @@ Perl 入学式 online 版では、基本的に Web ブラウザ版の環境で�
 
 <img src="image/wandbox02.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## Wandbox
@@ -65,6 +69,8 @@ Perl 入学式 online 版では、基本的に Web ブラウザ版の環境で�
 `Load template` のリンクをクリックします。
 
 <img src="image/wandbox03.png" align='left'>
+
+<br clear="all">
 
 ---
 
@@ -74,6 +80,8 @@ Perl 入学式 online 版では、基本的に Web ブラウザ版の環境で�
 
 <img src="image/wandbox04.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## Wandbox
@@ -81,6 +89,8 @@ Perl 入学式 online 版では、基本的に Web ブラウザ版の環境で�
 下にプログラムの実行結果が表示されます。このようにして学習を進めていきます。
 
 <img src="image/wandbox05.png" align='left'>
+
+<br clear="all">
 
 ---
 

--- a/1st/part3.md
+++ b/1st/part3.md
@@ -66,6 +66,8 @@ ___
 
 <ruby>Ruby<rt>ルビー</rt></ruby>、<ruby>Python<rt>パイソン</rt></ruby>、<ruby>PHP<rt>ピーエイチピー</rt></ruby>と並ぶ軽量言語(<ruby>Lightweight Language<rt>ライトウェイト ランゲージ</rt></ruby>)と呼ばれるカテゴリのプログラミング言語の1つです。
 
+<br clear="all">
+
 ___
 ## Perlの登場
 PerlはC言語や<ruby>sed<rt>セド</rt></ruby>、<ruby>awk<rt>オーク</rt></ruby>の影響を受けた動的型付け言語です。

--- a/1st/slide.md
+++ b/1st/slide.md
@@ -70,6 +70,8 @@ Perl 実行環境として利用する Wandbox の利用方法です。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/wandbox01.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## Wandbox
@@ -80,6 +82,8 @@ Perl 実行環境として利用する Wandbox の利用方法です。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/wandbox02.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## Wandbox
@@ -87,6 +91,8 @@ Perl 実行環境として利用する Wandbox の利用方法です。
 `Load template` のリンクをクリックします。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/wandbox03.png" align='left'>
+
+<br clear="all">
 
 ---
 
@@ -98,6 +104,8 @@ Perl 実行環境として利用する Wandbox の利用方法です。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/wandbox04.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## Wandbox
@@ -107,6 +115,8 @@ Perl 実行環境として利用する Wandbox の利用方法です。
 このようにエディタで入力を行い、ターミナルで実行結果を確認しながら学習を進めていきます。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/wandbox05.png" align='left'>
+
+<br clear="all">
 
 ---
 
@@ -120,6 +130,8 @@ Perl 実行環境として利用する Wandbox の利用方法です。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/wandbox07.png" align='right'>
 
+<br clear="all">
+
 ---
 
 ## Wandbox
@@ -131,6 +143,8 @@ Wandbox で書いたコードを共有することもできます。
 共有すると URL に紐づいてコードがインターネット上に残ります。気をつけてください。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/wandbox08.png" align='left'>
+
+<br clear="all">
 
 ---
 
@@ -144,6 +158,8 @@ Wandbox で書いたコードを共有することもできます。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/appslideshare01.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## スライド同期くん
@@ -156,6 +172,8 @@ Wandbox で書いたコードを共有することもできます。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/appslideshare02.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## スライド同期くん
@@ -164,6 +182,8 @@ Wandbox で書いたコードを共有することもできます。
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/appslideshare03.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## 手元の PC で Perl 実行環境がある場合・または構築する場合
@@ -171,6 +191,8 @@ Wandbox で書いたコードを共有することもできます。
 すでに手元の PC に環境がある方は、その環境を利用してください。
 
 PC への環境構築の方法は、<a href="https://github.com/perl-entrance-org/workshop-2019/blob/master/1st/part1.md" target="_blank">2019 年度資料の「第 1 回　第 1 部」</a>にて公開しています。
+
+<br clear="all">
 
 ---
 
@@ -263,6 +285,8 @@ PC への環境構築の方法は、<a href="https://github.com/perl-entrance-or
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/1st/image/larry.jpg" align='right'>
 
 <ruby>Ruby<rt>ルビー</rt></ruby>、<ruby>Python<rt>パイソン</rt></ruby>、<ruby>PHP<rt>ピーエイチピー</rt></ruby>と並ぶ軽量言語(<ruby>Lightweight Language<rt>ライトウェイト ランゲージ</rt></ruby>)と呼ばれるカテゴリのプログラミング言語の 1 つです。
+
+<br clear="all">
 
 ---
 

--- a/2nd/slide.md
+++ b/2nd/slide.md
@@ -820,6 +820,8 @@ Wandbox の場合には、画面左上、バージョン情報の下にある `R
 
 <img src="https://raw.githubusercontent.com/perl-entrance-org/workshop-basic-online/master/2nd/image/wandbox10.png" align='left'>
 
+<br clear="all">
+
 ---
 
 ## コマンドライン引数


### PR DESCRIPTION
GitHub で Markdown テキストをそのまま見たとき、img 要素の align 属性がスライドの区切りを超えて有効になっていて見づらかった表示の解決です。

解決と言っても、align 属性付き img 要素があるスライドブロックの最後に `<br clear="all">` を書いただけ。