### PR TITLE
Add chained comparison

### DIFF
--- a/2nd/slide.md
+++ b/2nd/slide.md
@@ -846,7 +846,7 @@ if ( $small < $medium <= $large ) { # Perl 5.30までのバージョンではエ
 上記の例の場合、以下のように解釈されます。
 
 ```perl
-$small < $medium  && $medium <= $large
+$small < $medium && $medium <= $large
 ```
 
 ---
@@ -859,9 +859,11 @@ $small < $medium  && $medium <= $large
 $small < $medium < $large
 ```
 
-Perl 5.30 以前では、上記のように、に 3 つ以上の値を同時に比較することはできません。
+この 3 つ以上の値の比較は Perl 5.32 から導入されました。
 
-下記のようなエラーとなります。
+<a href="https://perldoc.perl.org/perl5320delta#Chained-comparisons-capability">chained comparison</a> = **連鎖比較** とよびます。
+
+Perl 5.30 以前では、連鎖比較 することはできません。下記のようなエラーとなります。
 
     syntax error at sample.pl line 5, near "$medium <"
 
@@ -881,7 +883,13 @@ if ( $small < $medium && $medium <= $large ) {
 }
 ```
 
-`$small < $medium` かつ `$medium <= $large` というように、論理演算子を使って比較することも可能です。
+Perl 5.30 以前のコードでは連鎖比較は利用されていないため、
+
+```perl
+$small < $medium && $medium <= $large
+```
+
+というように、論理演算子を使って 3 つ以上の値の比較を行なっています。
 
 ---
 

--- a/2nd/slide.md
+++ b/2nd/slide.md
@@ -863,7 +863,7 @@ $small < $medium < $large
 
 <a href="https://perldoc.perl.org/perl5320delta#Chained-comparisons-capability">chained comparison</a> = **連鎖比較** とよびます。
 
-Perl 5.30 以前では、連鎖比較 することはできません。下記のようなエラーとなります。
+Perl 5.30 以前では、連鎖比較を利用することはできません。下記のようなエラーとなります。
 
     syntax error at sample.pl line 5, near "$medium <"
 

--- a/2nd/slide.md
+++ b/2nd/slide.md
@@ -883,7 +883,7 @@ if ( $small < $medium && $medium <= $large ) {
 }
 ```
 
-Perl 5.30 以前のコードでは連鎖比較は利用されていないため、
+Perl 5.30 以前では、連鎖比較を利用することはできないため、
 
 ```perl
 $small < $medium && $medium <= $large

--- a/2nd/slide.md
+++ b/2nd/slide.md
@@ -856,7 +856,7 @@ $small < $medium && $medium <= $large
 ### 3 つ以上の値を比較したい場合（ Perl 5.30 以前）
 
 ```perl
-$small < $medium < $large
+$small < $medium <= $large
 ```
 
 この 3 つ以上の値の比較は Perl 5.32 から導入されました。


### PR DESCRIPTION
Perl 5.32 から導入された３つ以上の値を一気に比較する `chained comparison` について、「連鎖比較」という名称を設定し、それに伴って説明を変更